### PR TITLE
Update CodeViewer.razor

### DIFF
--- a/Shared/CodeViewer.razor
+++ b/Shared/CodeViewer.razor
@@ -1,7 +1,7 @@
 @using System.Text.RegularExpressions;
 @inject IJSRuntime JSRuntime
 
-<pre style="max-height: 500px; overflow: auto; font-size: 12px" @ref="pre">@source</pre>
+<pre style="min-height: 500px; overflow: auto; font-size: 12px" @ref="pre">@source</pre>
 
 @code {
     private ElementReference pre;


### PR DESCRIPTION
The height specified presently makes the code window unnecessarily small, with the result being the code samples are too difficult to read on larger screens. This change guarantees the layout you want while making it easier for people with 4k monitors to read more of the code.